### PR TITLE
improve Blink1.open to use instance_eval for convenient

### DIFF
--- a/lib/blink1.rb
+++ b/lib/blink1.rb
@@ -79,14 +79,18 @@ class Blink1
     devs
   end
 
-  def self.open option = nil
+  def self.open option = nil, &block
     b = self.new(option)
     b.open if option.nil?
-    if block_given?
-      yield(b)
-      b.close
+    if block
+      begin
+        b.instance_eval &block
+      ensure
+        b.close
+      end
+    else
+      b
     end
-    b
   end
 
 end


### PR DESCRIPTION
`Blink1.open` is so convenient!
I've improved it to be no longer need the argument for the block. 

Example:

``` ruby
Blink1.open do
  blink 0xff, 0xff, 0xff, 3
end
```

The rb-blink1 is very useful. Thank you for your work. :smile: 
